### PR TITLE
Move ZMQ socket bind to poll thread to prevent blocking

### DIFF
--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -76,15 +76,7 @@ void ZmqServer::bind()
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());
     }
 
-    int rc = zmq_bind(m_socket, m_endpoint.c_str());
-    if (rc != 0)
-    {
-        SWSS_LOG_THROW("zmq_bind failed on endpoint: %s, zmqerrno: %d",
-            m_endpoint.c_str(),
-            zmq_errno());
-    }
-
-    SWSS_LOG_DEBUG("ZmqServer bind to endpoint: %s", m_endpoint.c_str());
+    SWSS_LOG_NOTICE("ZmqServer socket created, actual bind to %s will occur asynchronously in mqPollThread to prevent blocking", m_endpoint.c_str());
 
     startMqPollThread();
 }
@@ -152,6 +144,14 @@ void ZmqServer::mqPollThread()
 {
     SWSS_LOG_ENTER();
     SWSS_LOG_NOTICE("mqPollThread begin");
+
+    SWSS_LOG_NOTICE("Attempting to bind to zmq endpoint: %s", m_endpoint.c_str());
+    if (zmq_bind(m_socket, m_endpoint.c_str()) != 0)
+    {
+        SWSS_LOG_THROW("zmq_bind failed on endpoint: %s, zmqerrno: %d",
+            m_endpoint.c_str(),
+            zmq_errno());
+    }
 
     // zmq_poll will use less CPU
     zmq_pollitem_t poll_item;

--- a/common/zmqserver.cpp
+++ b/common/zmqserver.cpp
@@ -76,7 +76,7 @@ void ZmqServer::bind()
         zmq_setsockopt(m_socket, ZMQ_BINDTODEVICE, m_vrf.c_str(), m_vrf.length());
     }
 
-    SWSS_LOG_NOTICE("ZmqServer socket created, actual bind to %s will occur asynchronously in mqPollThread to prevent blocking", m_endpoint.c_str());
+    SWSS_LOG_NOTICE("ZmqServer socket created, actual bind to %s will occur in mqPollThread to prevent blocking", m_endpoint.c_str());
 
     startMqPollThread();
 }


### PR DESCRIPTION
**Why I did it**
- In scale scenarios, `zmq_bind()` can take significant time to complete
- Orchestration agent gets blocked during ZmqServer initialization
- Synchronous bind in main thread delays startup and impacts system responsiveness

**How I did it**
- Moved `zmq_bind()` call from `ZmqServer::bind()` to `mqPollThread()`
- Socket creation and configuration remain in main thread
- Actual bind operation now happens in background poll thread